### PR TITLE
Fix to avoid extreme memory leak in MC workflows

### DIFF
--- a/include/Pythia8Plugins/LHAPDF6.h
+++ b/include/Pythia8Plugins/LHAPDF6.h
@@ -135,7 +135,7 @@ void LHAPDF6::init(string setName, int member, Info *info) {
       info->errorMsg("Error in LHAPDF6::init: could not initialize PDF "
                      + setName);
       return;
-    } else LHAPDF6Interface::initializedSets[id] = make_pair(pdfInfo,0);
+    } else LHAPDF6Interface::initializedSets[id] = make_pair(pdfInfo,1);
   } else {
     pair< LHAPDF6Interface::pdf_Info, int > &set
       = LHAPDF6Interface::initializedSets[id];


### PR DESCRIPTION
@Dr15Jones found that there was extreme memory leak in MC workflows. He suggested this patch to avoid it.