### PR TITLE
initialize bools

### DIFF
--- a/src/TimeShower.cc
+++ b/src/TimeShower.cc
@@ -73,6 +73,10 @@ const double TimeShower::PROBLIMIT = 0.99;
 void TimeShower::init( BeamParticle* beamAPtrIn,
   BeamParticle* beamBPtrIn) {
 
+  // initialize bools
+  doTrialNow = false;
+  canEnhanceET = false;
+
   // Store input pointers for future use.
   beamAPtr           = beamAPtrIn;
   beamBPtr           = beamBPtrIn;


### PR DESCRIPTION
A crash was found in Phase2 production using 9_3_6:
https://cms-unified.web.cern.ch/cms-unified//joblogs/pdmvserv_task_TSG-PhaseIITDRFall17GS-00009__v1_T_180403_202250_828/139/TSG-PhaseIITDRFall17GS-00009_0/c0eb431e-3776-11e8-a946-02163e01877e-52-3-logArchive/job/WMTaskSpace/cmsRun1/cmsRun1-stdout.log

I recompiled pythia8 and dependent packages with debug symbols, which produced the following information when run:
```
Thread 7 "cmsRun" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffd2d7e700 (LWP 58729)]
0x00007fffddfdbef4 in Pythia8::TimeShower::pT2nextQED (this=0x7fffd5842700, pT2begDip=0.20562544615866121, pT2sel=0, dip=..., event=...) at src/TimeShower.cc:2415
2415        if (canEnhanceET) emitCoefTot *= userHooksPtr->enhanceFactor("fsr:Q2QA");
(gdb) backtrace
#0  0x00007fffddfdbef4 in Pythia8::TimeShower::pT2nextQED (this=0x7fffd5842700, pT2begDip=0.20562544615866121, pT2sel=0, dip=..., event=...) at src/TimeShower.cc:2415
#1  0x00007fffddfcfcb2 in Pythia8::TimeShower::showerQED (this=0x7fffd5842700, i1=112, i2=113, event=..., pTmax=1.0187130221146139) at src/TimeShower.cc:446
#2  0x00007fffde144289 in Pythia8::ParticleDecays::decay (this=0x7fffba27c428, iDec=48, event=...) at src/ParticleDecays.cc:330
#3  0x00007fffde06718b in Pythia8::HadronLevel::next (this=0x7fffba27bd00, event=...) at src/HadronLevel.cc:262
#4  0x00007fffddeb9e9d in Pythia8::Pythia::forceHadronLevel (this=0x7fffba240000, findJunctions=true) at src/Pythia.cc:2014
#5  0x00007fffddeb7e35 in Pythia8::Pythia::next (this=0x7fffba240000) at src/Pythia.cc:1659
#6  0x00007fffde4758b1 in gen::Py8PtGun::generatePartonsAndHadronize (this=this@entry=0x7fffe14cd858) at /uscms_data/d3/pedrok/phase2/test/CMSSW_9_3_6/src/GeneratorInterface/Pythia8Interface/plugins/Py8PtGun.cc:108
#7  0x00007fffde47a4b0 in edm::GeneratorFilter<gen::Py8PtGun, gen::ExternalDecayDriver>::filter (this=0x7fffe14cd800, ev=...) at /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_3_6/src/GeneratorInterface/Core/interface/GeneratorFilter.h:150
...
(gdb) frame 0
#0  0x00007fffddfdbef4 in Pythia8::TimeShower::pT2nextQED (this=0x7fffd5842700, pT2begDip=0.20562544615866121, pT2sel=0, dip=..., event=...) at src/TimeShower.cc:2415
2415        if (canEnhanceET) emitCoefTot *= userHooksPtr->enhanceFactor("fsr:Q2QA");
(gdb) print canEnhanceET
$1 = 63
(gdb) print emitCoefTot
$2 = 0.064956651662100753
(gdb) print userHooksPtr
$3 = (Pythia8::UserHooks *) 0x0
(gdb) ptype canEnhanceET
type = bool
(gdb) print canEnhanceTrial
$4 = false
(gdb) print canEnhanceEmission
$5 = false
(gdb) print canEnhanceET
$6 = 63
(gdb) print doTrialNow
$7 = 32
```

The member bools `canEnhanceET` and `doTrialNow` do not have boolean values because they are not initialized properly. `pT2nextQED()` can be called by either `pTnext()` or `showerQED()`. The former initializes these bools, the latter does not (and the latter appears in the stack trace above).

The crash no longer occurs with the fix in this PR.