### PR TITLE
Backport UncertaintyBand options from Pythia 8.230 to 8.226

### DIFF
--- a/include/Pythia8/SpaceShower.h
+++ b/include/Pythia8/SpaceShower.h
@@ -130,7 +130,8 @@ public:
 
   // Calculate uncertainty-band weights for accepted/rejected trial branching.
   void calcUncertainties(bool accept, double pAcceptIn, double pT20in,
-    SpaceDipoleEnd* dip, Particle* motherPtr, Particle* sisterPtr);
+    double enhance, double vp, SpaceDipoleEnd* dip, Particle* motherPtr,
+    Particle* sisterPtr);
 
   // Tell if latest scattering was a gamma->qqbar.
   bool wasGamma2qqbar() { return gamma2qqbar; }
@@ -245,7 +246,8 @@ private:
          doPhiPolAsymHard, doPhiIntAsym, doRapidityOrder, useFixedFacScale,
          doSecondHard, canVetoEmission, hasUserHooks, alphaSuseCMW,
          singleWeakEmission, vetoWeakJets, weakExternal, doRapidityOrderMPI,
-         doUncertainties, uVarMuSoftCorr, uVarMPIshowers, doMPI, gamma2qqbar;
+         doUncertainties, uVarMuSoftCorr, uVarMPIshowers, doMPI, gamma2qqbar,
+         doDipoleRecoil, doPartonVertex;
   int    pTmaxMatch, pTdampMatch, alphaSorder, alphaSnfmax, alphaEMorder,
          nQuarkIn, enhanceScreening, weakMode;
   double pTdampFudge, mc, mb, m2c, m2b, renormMultFac, factorMultFac,
@@ -254,7 +256,7 @@ private:
          ecmRef, ecmPow, pTmin, sCM, eCM, pT0, pTminChgQ, pTminChgL, pT20,
          pT2min, pT2minChgQ, pT2minChgL, pTweakCut, pT2weakCut, pTmaxFudgeMPI,
          strengthIntAsym, weakEnhancement, mZ, gammaZ, thetaWRat, mW, gammaW,
-         weakMaxWt, vetoWeakDeltaR2, dASmax, cNSpTmin;
+         weakMaxWt, vetoWeakDeltaR2, dASmax, cNSpTmin, uVarpTmin2, overFactor;
 
   // alphaStrong and alphaEM calculations.
   AlphaStrong alphaS;

--- a/include/Pythia8/TimeShower.h
+++ b/include/Pythia8/TimeShower.h
@@ -145,8 +145,8 @@ public:
   bool initUncertainties();
 
   // Calculate uncertainty-band weights for accepted/rejected trial branching.
-  void calcUncertainties(bool accept, double pAccept,
-    TimeDipoleEnd* dip, Particle* radPtr, Particle* emtPtr);
+  void calcUncertainties(bool accept, double pAccept, double enhance,
+    double vp, TimeDipoleEnd* dip, Particle* radPtr, Particle* emtPtr);
 
   // Tell which system was the last processed one.
   virtual int system() const {return iSysSel;};
@@ -257,7 +257,8 @@ private:
          globalRecoil, useLocalRecoilNow, doSecondHard, hasUserHooks,
          singleWeakEmission, alphaSuseCMW, vetoWeakJets, allowMPIdipole,
          weakExternal, recoilDeadCone, doUncertainties, uVarMuSoftCorr,
-         uVarMPIshowers;
+         uVarMPIshowers, doDipoleRecoil, doPartonVertex, noResVariations,
+         noProcVariations;
   int    pTmaxMatch, pTdampMatch, alphaSorder, alphaSnfmax, nGluonToQuark,
          weightGluonToQuark, alphaEMorder, nGammaToQuark, nGammaToLepton,
          nCHV, idHV, alphaHVorder, nMaxGlobalRecoil, weakMode;
@@ -269,7 +270,8 @@ private:
          pTweakCut, pT2weakCut, mMaxGamma, m2MaxGamma, octetOniumFraction,
          octetOniumColFac, mZ, gammaZ, thetaWRat, mW, gammaW, CFHV, nFlavHV,
          alphaHVfix, LambdaHV, pThvCut, pT2hvCut, mHV, pTmaxFudgeMPI,
-         weakEnhancement, vetoWeakDeltaR2, dASmax, cNSpTmin;
+         weakEnhancement, vetoWeakDeltaR2, dASmax, cNSpTmin, uVarpTmin2,
+         overFactor;
 
   // alphaStrong and alphaEM calculations.
   AlphaStrong alphaS;

--- a/share/Pythia8/xmldoc/UpdateHistory.xml
+++ b/share/Pythia8/xmldoc/UpdateHistory.xml
@@ -11,6 +11,18 @@ but this should only affect a small part of the user code.
 <h3>Main news by version</h3> 
  
 <ul> 
+
+<li>Backported from 8.230: 6 October 2017 
+<ul> 
+ 
+<li>The machinery for 
+<aloc href="Variations">Automated Shower Variations</aloc> 
+has been extended to stop variation uncertainty evaluation 
+below some scale, so as to better correlate the event weighting 
+with the harder part of the event evolution.</li> 
+ 
+</ul> 
+</li> 
  
 <li>8.226: 26 April 2017 
 <ul> 

--- a/share/Pythia8/xmldoc/Variations.xml
+++ b/share/Pythia8/xmldoc/Variations.xml
@@ -70,6 +70,52 @@ enter in the reweightings.
 </flag> 
  
 <p/> 
+The following parameters allow one to switch off all 
+variations below a fixed threshold.  It is specified in terms of 
+a multiplier for the <code>TimeShower:pTmin</code> squared (FSR) or 
+<code>SpaceShower:pT0Ref</code> squared (ISR). 
+A separate cutoff can be specified for ISR or FSR: 
+<parm name="UncertaintyBands:ISRpTmin2Fac" default="4.0" min="0.0" 
+max="100.0"> 
+Variations will not be performed for ISR branchings 
+occurring below the threshold fixed by 
+<code>UncertaintyBands:ISRpTmin2Fac</code> times 
+<code> SpaceShower:pT0Ref^2 </code>. 
+</parm> 
+<parm name="UncertaintyBands:FSRpTmin2Fac" default="4.0" min="0.0" 
+max="100.0"> 
+Variations will not be performed for FSR branchings 
+occurring below the threshold fixed by 
+<code>UncertaintyBands:FSRpTmin2Fac</code> times 
+<code> TimeShower:pTmin^2 </code>. 
+</parm> 
+ 
+<p/> 
+To ensure coverage of the phase space for the variations, the overestimate 
+of the Sudakov used in the veto algorithm is artifically increased, which 
+is compensated in the rejection factor. A larger factor reduces fluctuations 
+at the cost of a longer generation time. The default parameters chosen are 
+a compromise between time and fluctuations. 
+<parm name="UncertaintyBands:overSampleFSR" default="3.0" min="1.0" 
+max="10.0"> 
+The QCD FSR Sudakov is artificially increased by this factor. The increase 
+is compensated for in the veto algorithm. 
+</parm> 
+<parm name="UncertaintyBands:overSampleISR" default="2.0" min="1.0" 
+max="10.0"> 
+The similar parameter for the QCD ISR Sudakov. 
+</parm> 
+ 
+<p/> 
+The user can control whether the variations are calculated in all or 
+specific stages of the event generation: 
+<modepick name="UncertaintyBands:type" default="0" min="0" max="2"> 
+<option value="0">  Variations are calculated where allowed; </option> 
+<option value="1">   only for the process (including ISR and FSR); </option> 
+<option value="2">   only for resonance decay and showering; </option> 
+</modepick> 
+ 
+<p/> 
 <b>UserHooks Warning:</b> the calculation of uncertainty variations 
 will only be consistent in the absence of any external modifications 
 to the shower branching probabilities via the 

--- a/src/TimeShower.cc
+++ b/src/TimeShower.cc
@@ -271,6 +271,12 @@ void TimeShower::init( BeamParticle* beamAPtrIn,
   uVarNflavQ         = settingsPtr->mode("UncertaintyBands:nFlavQ");
   uVarMPIshowers     = settingsPtr->flag("UncertaintyBands:MPIshowers");
   cNSpTmin           = settingsPtr->parm("UncertaintyBands:cNSpTmin");
+  uVarpTmin2         = pT2colCut;
+  uVarpTmin2        *= settingsPtr->parm("UncertaintyBands:FSRpTmin2Fac");
+  int varType        = settingsPtr->mode("UncertaintyBands:type");
+  noResVariations    = (varType == 1) ? true: false;
+  noProcVariations   = (varType == 2) ? true: false;
+  overFactor         = settingsPtr->parm("UncertaintyBands:overSampleFSR");
 
 }
 
@@ -2079,7 +2085,7 @@ void TimeShower::pT2nextQCD(double pT2begDip, double pT2sel,
   doUncertaintiesNow   = doUncertainties;
   if (!uVarMPIshowers && dip.system != 0
     && partonSystemsPtr->getInA(dip.system) != 0) doUncertaintiesNow = false;
-  double overFac       = doUncertaintiesNow ? 2.0 : 1.0;
+  double overFac       = doUncertaintiesNow ? overFactor : 1.0;
 
   // Set default values for enhanced emissions.
   bool isEnhancedQ2QG, isEnhancedG2QQ, isEnhancedG2GG;
@@ -3228,15 +3234,27 @@ bool TimeShower::branch( Event& event, bool isInterleaved) {
   bool acceptEvent = true;
   if (pAccept < 1.0) acceptEvent = (rndmPtr->flat() < pAccept);
 
+  // Determine if this FSR is part of process or resonance showering
+  bool inResonance = (partonSystemsPtr->getInA(iSysSel) == 0) ? true : false;
+
   // If doing uncertainty variations, calculate accept/reject reweightings.
   doUncertaintiesNow = doUncertainties;
-  if (!uVarMPIshowers && iSysSel != 0
-    && partonSystemsPtr->getInA(iSysSel) != 0) doUncertaintiesNow = false;
-  if (doUncertaintiesNow)
-    calcUncertainties( acceptEvent, pAccept, dipSel, &rad, &emt);
+  // Check if variations are allowed in MPIs.
+  if (!uVarMPIshowers && iSysSel != 0 && !inResonance)
+    doUncertaintiesNow = false;
 
-  // Return false if we decided to reject this branching.
-  if( !acceptEvent ) return false;
+  // Check if to allow variations in resonance decays.
+  if (noResVariations && inResonance) doUncertaintiesNow = false;
+
+  // Check if to allow variations in process.
+  if (noProcVariations && iSysSel==0 && !inResonance)
+    doUncertaintiesNow = false;
+
+  // Check if below cutoff for calculating variations
+  if ( dipSel->pT2 < uVarpTmin2 ) doUncertaintiesNow = false;
+
+  // Early return if allowed.
+  if (!doUncertaintiesNow && !acceptEvent) return false;
 
   // Rescatter: if the recoiling partner is not in the same system
   //            as the radiator, fix up intermediate systems (can lead
@@ -3339,7 +3357,6 @@ bool TimeShower::branch( Event& event, bool isInterleaved) {
   }
 
   // Allow veto of branching. If so restore event record to before emission.
-  bool inResonance = (partonSystemsPtr->getInA(iSysSel) == 0) ? true : false;
   if ( (canVetoEmission && userHooksPtr->doVetoFSREmission( eventSizeOld,
     event, iSysSel, inResonance))
     || (canMergeFirst && mergingHooksPtr->doVetoEmission( event )) ) {
@@ -3361,14 +3378,15 @@ bool TimeShower::branch( Event& event, bool isInterleaved) {
     }
     return false;
   }
+  // Default settings for uncertainty calculations.
+  double weight = 1.;
+  double vp = 0.;
+  bool vetoedEnhancedEmission = false;
 
   // Calculate event weight for enhanced emission rate.
   if (canEnhanceET) {
-
     // Check if emission weight was enhanced. Get enhance weight factor.
     bool foundEnhance = false;
-    double weight = 1.;
-    double vp = 0.;
     // Move backwards as last elements have highest pT, thus are chosen
     // splittings.
     for ( map<double,pair<string,double> >::reverse_iterator
@@ -3384,7 +3402,6 @@ bool TimeShower::branch( Event& event, bool isInterleaved) {
     }
 
     // Check emission veto.
-    bool vetoedEnhancedEmission = false;
     if (foundEnhance && rndmPtr->flat() < vp ) vetoedEnhancedEmission = true;
     // Calculate new event weight.
     double rwgt = 1.;
@@ -3396,32 +3413,40 @@ bool TimeShower::branch( Event& event, bool isInterleaved) {
 
     // Set events weights, so that these could be used externally.
     double wtOld = userHooksPtr->getEnhancedEventWeight();
-    if (!doTrialNow && canEnhanceEmission)
+    if (!doTrialNow && canEnhanceEmission && !doUncertaintiesNow)
       userHooksPtr->setEnhancedEventWeight(wtOld*rwgt);
     if ( doTrialNow && canEnhanceTrial)
       userHooksPtr->setEnhancedTrial(sqrt(dipSel->pT2), weight);
+    // Increment counter to handle counting of rejected emissions.
+    if (vetoedEnhancedEmission && canEnhanceEmission) infoPtr->addCounter(40);
+  }
 
-    // Veto if necessary.
-    if (vetoedEnhancedEmission && canEnhanceEmission) {
+  // Emission veto is a phase space restriction, and should not be included
+  // in the uncertainty calculation.
+  if (vetoedEnhancedEmission) acceptEvent = false;
+  if (doUncertaintiesNow) calcUncertainties( acceptEvent, pAccept, weight, vp,
+    dipSel, &rad, &emt);
 
-      event.popBack( event.size() - eventSizeOld);
-      event[iRadBef].status( iRadStatusV);
-      event[iRadBef].daughters( iRadDau1V, iRadDau2V);
-      if (useLocalRecoilNow && isrTypeNow == 0) {
-        event[iRecBef].status( iRecStatusV);
-        event[iRecBef].daughters( iRecDau1V, iRecDau2V);
-      } else if (useLocalRecoilNow) {
-        event[iRecBef].mothers( iRecMot1V, iRecMot2V);
-        if (iRecMot1V == beamOff1) event[beamOff1].daughter1( ev1Dau1V);
-        if (iRecMot1V == beamOff2) event[beamOff2].daughter1( ev2Dau1V);
-      } else {
-        for (int iG = 0; iG < int(iGRecBef.size()); ++iG) {
-          event[iGRecBef[iG]].statusPos();
-          event[iGRecBef[iG]].daughters( 0, 0);
-        }
+  // Return false if we decided to reject this branching.
+  // Veto if necessary.
+  if ( (vetoedEnhancedEmission && canEnhanceEmission) || !acceptEvent) {
+    event.popBack( event.size() - eventSizeOld);
+    event[iRadBef].status( iRadStatusV);
+    event[iRadBef].daughters( iRadDau1V, iRadDau2V);
+    if (useLocalRecoilNow && isrTypeNow == 0) {
+      event[iRecBef].status( iRecStatusV);
+      event[iRecBef].daughters( iRecDau1V, iRecDau2V);
+    } else if (useLocalRecoilNow) {
+      event[iRecBef].mothers( iRecMot1V, iRecMot2V);
+      if (iRecMot1V == beamOff1) event[beamOff1].daughter1( ev1Dau1V);
+      if (iRecMot1V == beamOff2) event[beamOff2].daughter1( ev2Dau1V);
+    } else {
+      for (int iG = 0; iG < int(iGRecBef.size()); ++iG) {
+        event[iGRecBef[iG]].statusPos();
+        event[iGRecBef[iG]].daughters( 0, 0);
       }
-      return false;
     }
+    return false;
   }
 
   // For global recoil restore the one nominal recoiler, for bookkeeping.
@@ -3839,8 +3864,8 @@ bool TimeShower::initUncertainties() {
 
 // Calculate uncertainties for the current event.
 
-void TimeShower::calcUncertainties(bool accept, double pAccept,
-  TimeDipoleEnd* dip, Particle* radPtr, Particle* emtPtr) {
+void TimeShower::calcUncertainties(bool accept, double pAccept, double enhance,
+  double vp, TimeDipoleEnd* dip, Particle* radPtr, Particle* emtPtr) {
 
   // Sanity check.
   if (!doUncertainties || !doUncertaintiesNow || nUncertaintyVariations <= 0)
@@ -3857,6 +3882,9 @@ void TimeShower::calcUncertainties(bool accept, double pAccept,
   // Make vector sizes + 1 since 0 = default and variations start at 1.
   vector<double> uVarFac(nUncertaintyVariations + 1, 1.0);
   vector<bool> doVar(nUncertaintyVariations + 1, false);
+  // For the case of biasing, the nominal weight might not be unity.
+  doVar[0] = true;
+  uVarFac[0] = 1.0;
 
   // Extract relevant quantities.
   int idEmt = emtPtr->id();
@@ -3941,22 +3969,23 @@ void TimeShower::calcUncertainties(bool accept, double pAccept,
   }
 
   // Ensure 0 < PacceptPrime < 1 (with small margins).
-  for (int iWeight = 1; iWeight<=nUncertaintyVariations; ++iWeight) {
+  for (int iWeight = 0; iWeight<=nUncertaintyVariations; ++iWeight) {
     if (!doVar[iWeight]) continue;
     double pAcceptPrime = pAccept * uVarFac[iWeight];
     if (pAcceptPrime > PROBLIMIT) uVarFac[iWeight] *= PROBLIMIT / pAcceptPrime;
   }
 
   // Apply reject or accept reweighting factors according to input decision.
-  for (int iWeight = 1; iWeight <= nUncertaintyVariations; ++iWeight) {
+  for (int iWeight = 0; iWeight <= nUncertaintyVariations; ++iWeight) {
     if (!doVar[iWeight]) continue;
     // If trial accepted: apply ratio of accept probabilities.
-    if (accept) infoPtr->reWeight(iWeight, uVarFac[iWeight]);
+    if (accept) infoPtr->reWeight(iWeight,
+      uVarFac[iWeight] / ((1.0 - vp) * enhance) );
     // If trial rejected : apply Sudakov reweightings.
     else {
       // Check for near-singular denominators (indicates too few failures,
       // and hence would need to increase headroom).
-      double denom = 1. - pAccept;
+      double denom = 1. - pAccept*(1.0 - vp);
       if (denom < REJECTFACTOR) {
         stringstream message;
         message << iWeight;
@@ -3964,7 +3993,8 @@ void TimeShower::calcUncertainties(bool accept, double pAccept,
           message.str());
       }
       // Force reweighting factor > 0.
-      double reWtFail = max(0.01, (1. - uVarFac[iWeight] * pAccept) / denom);
+      double reWtFail = max(0.01, (1. - uVarFac[iWeight] * pAccept / enhance)
+        / denom);
       infoPtr->reWeight(iWeight, reWtFail);
     }
   }


### PR DESCRIPTION
Enable these options that were introduced with 8.230 and greatly reduce spread of the weights:
```
UncertaintyBands:overSampleFSR = 10.0
UncertaintyBands:overSampleISR = 10.0
UncertaintyBands:FSRpTmin2Fac = 20
UncertaintyBands:ISRpTmin2Fac = 1
```
Weight distributions from 8.226 modified with this patch (left) and 8.226 default (right):
![psweights-8226mod-vs-8226](https://user-images.githubusercontent.com/1311783/49881764-636ff600-fe2f-11e8-8535-734b369389fa.png)
