### PR TITLE
BeamRemnants update for LHE events in 240

### DIFF
--- a/include/Pythia8/BeamRemnants.h
+++ b/include/Pythia8/BeamRemnants.h
@@ -66,6 +66,7 @@ private:
 
   // Initialization data, read from Settings.
   bool   doPrimordialKT, allowRescatter, doRescatterRestoreY, doReconnect;
+  bool   doHardKTOnlyLHE;
   double primordialKTsoft, primordialKThard, primordialKTremnant,
          halfScaleForKT, halfMassForKT, reducedKTatHighY;
   int    remnantMode, reconnectMode;

--- a/share/Pythia8/xmldoc/BeamRemnants.xml
+++ b/share/Pythia8/xmldoc/BeamRemnants.xml
@@ -75,10 +75,21 @@ interactions, <ei>m</ei> the mass of the system, and
 <ei>m_half</ei> and <ei>y_damp</ei> parameters defined below. 
 Furthermore each separately defined beam remnant has a distribution 
 of width <ei>sigma_remn</ei>, independently of kinematical variables. 
- 
+<p/>
+Note that, for external (LHE) events <ei>Q_half</ei> is treated as
+zero. This is so that LHE events with low-pT extra jets (e.g., in
+the context of POWHEG-style merging) are given the same primordial kT
+as their Born-level counterparts.
+
 <flag name="BeamRemnants:primordialKT" default="on"> 
 Allow or not selection of primordial <ei>kT</ei> according to the 
 parameter values below. 
+</flag>
+
+<flag name="BeamRemnants:hardKTOnlyLHE" default="off"> 
+  Special treatment of primordial <ei>kT</ei> for LHE events, where the
+  scale might not correspond to the hard scale of the process.   If
+  set on, only hard <ei>kT</ei> is added.
 </flag> 
  
 <parm name="BeamRemnants:primordialKTsoft" default="0.9" min="0."> 
@@ -93,7 +104,8 @@ primordial <ei>kT</ei> to initiators in the hard-interaction limit.
  
 <parm name="BeamRemnants:halfScaleForKT" default="1.5" min="0."> 
 The scale <ei>Q_half</ei> in the equation above, defining the 
-half-way point between hard and soft interactions. 
+half-way point between hard and soft interactions. For external (LHE)
+events, this parameter is treated as zero. 
 </parm> 
  
 <parm name="BeamRemnants:halfMassForKT" default="1." min="0."> 

--- a/src/BeamRemnants.cc
+++ b/src/BeamRemnants.cc
@@ -53,6 +53,7 @@ bool BeamRemnants::init( Info* infoPtrIn, Settings& settings, Rndm* rndmPtrIn,
 
   // Width of primordial kT distribution.
   doPrimordialKT      = settings.flag("BeamRemnants:primordialKT");
+  doHardKTOnlyLHE     = settings.flag("BeamRemnants:hardKTOnlyLHE");
   primordialKTsoft    = settings.parm("BeamRemnants:primordialKTsoft");
   primordialKThard    = settings.parm("BeamRemnants:primordialKThard");
   primordialKTremnant = settings.parm("BeamRemnants:primordialKTremnant");
@@ -461,14 +462,26 @@ bool BeamRemnants::setKinematics( Event& event) {
     // Allow primordial kT reduction for small-mass and small-pT systems
     // (for hardest interaction pT -> renormalization scale so also 2 -> 1).
     if (doPrimordialKT) {
+      // Les Houches events use primordialKThard.
+      if (iSys == 0 && infoPtr->isLHA() && doHardKTOnlyLHE) {
+        kTwidthNow = primordialKThard;
+      }
+      // Internal processes and MPI use pT-dependent interpolation between
+      // primordialKThard and primordialKTsoft.
+      else {
+        // For hardest interaction pT -> renormalization scale so also 2 -> 1.
+        double scale = (iSys == 0) ? infoPtr->QRen(iDS)
+                                   : partonSystemsPtr->getPTHat(iSys);
+         kTwidthNow = (halfScaleForKT * primordialKTsoft
+           + scale * primordialKThard) / (halfScaleForKT + scale);
+      }
+      // Dampen primordial kT width for very low masses / extreme rapidities.
+      
       double mHat     = sqrt(sHatNow);
       double yDamp    = pow( (event[iInA].e() + event[iInB].e()) / mHat,
                         reducedKTatHighY );
       mHatDamp        = mHat / (mHat + halfMassForKT * yDamp);
-      double scale    = (iSys == 0) ? infoPtr->QRen(iDS)
-                      : partonSystemsPtr->getPTHat(iSys);
-      kTwidthNow      = ( (halfScaleForKT * primordialKTsoft
-      + scale * primordialKThard) / (halfScaleForKT + scale) ) * mHatDamp;
+      kTwidthNow     *= mHatDamp;
     }
 
     // Store properties of compensation systems and total compensation power.


### PR DESCRIPTION
BeamRemnants is modified so that there can be a different treatment for LHE events.
If the new flag:
BeamRemnants:hardKTOnlyLHE = on, then only hardKT is added to that part of the event.