### PR TITLE
Revert "change to 8240 in to handle high multiplicity bug"

### DIFF
--- a/src/SimpleTimeShower.cc
+++ b/src/SimpleTimeShower.cc
@@ -1,5 +1,5 @@
 // SimpleTimeShower.cc is a part of the PYTHIA event generator.
-// Copyright (C) 2019 Torbjorn Sjostrand.
+// Copyright (C) 2018 Torbjorn Sjostrand.
 // PYTHIA is licenced under the GNU GPL v2 or later, see COPYING for details.
 // Please respect the MCnet Guidelines, see GUIDELINES for details.
 
@@ -3077,16 +3077,12 @@ bool SimpleTimeShower::branch( Event& event, bool isInterleaved) {
   int iSysSelRec   = dipSel->systemRec;
 
   // Sometimes need to patch up colType in junction systems.
+  int idRec        = recBef.id();
   int colTypeTmp   = dipSel->colType;
-  int colTypeRec   = particleDataPtr->colType( recBef.id() );
-  // Negate colour type if recoiler is initial-state quark.
-  if (!recBef.isFinal()) colTypeRec = -colTypeRec;
-  int colTypeRad   = particleDataPtr->colType( idRad );
-  // Perform junction tests for all colour (anti)triplets.
-  if (colTypeRec ==  1 && colTypeTmp > 0) colTypeTmp = -colTypeTmp;
-  if (colTypeRec == -1 && colTypeTmp < 0) colTypeTmp = -colTypeTmp;
-  if (colTypeRad ==  1 && colTypeTmp < 0) colTypeTmp = -colTypeTmp;
-  if (colTypeRad == -1 && colTypeTmp > 0) colTypeTmp = -colTypeTmp;
+  if (idRec >  0 && idRec < 9 && colTypeTmp > 0) colTypeTmp = -colTypeTmp;
+  if (idRec > -9 && idRec < 0 && colTypeTmp < 0) colTypeTmp = -colTypeTmp;
+  if (idRad >  0 && idRad < 9 && colTypeTmp < 0) colTypeTmp = -colTypeTmp;
+  if (idRad > -9 && idRad < 0 && colTypeTmp > 0) colTypeTmp = -colTypeTmp;
 
   // Default OK for photon, photon_HV or gluon_HV emission.
   if (dipSel->flavour == 22 || dipSel->flavour == idHV) {


### PR DESCRIPTION
Reverts cms-externals/pythia8#22

Generators required to have two versions of 10_6_14.
- CMSSW_10_6_14 -> without https://github.com/cms-sw/cmsdist/pull/5949
- CMSSW_10_6_14_Pyt8240BugFix -> with https://github.com/cms-sw/cmsdist/pull/5949

Given that https://github.com/cms-sw/cmsdist/pull/5949 was already merged,
this is my plan
- build CMSSW_10_6_14_Pyt8240BugFix (done https://github.com/cms-sw/cmssw/issues/30540)
- revert https://github.com/cms-sw/cmsdist/pull/5949
- build CMSSW_10_6_14

In order to revert https://github.com/cms-sw/cmsdist/pull/5949 we need to create a new tag because another  #24 was merged in the middle
cc: @alberto-sanchez @agrohsje @efeyazgan @mkirsano @qliphy @SiewYan