### PR TITLE
msafety set to 1e-4

### DIFF
--- a/src/ResonanceDecays.cc
+++ b/src/ResonanceDecays.cc
@@ -27,7 +27,7 @@ const int    ResonanceDecays::NTRYCHANNEL = 10;
 const int    ResonanceDecays::NTRYMASSES  = 10000;
 
 // Mass above threshold for allowed decays.
-const double ResonanceDecays::MSAFETY     = 0.01;
+const double ResonanceDecays::MSAFETY     = 0.0001;
 
 // When constrainted kinematics cut high-mass tail of Breit-Wigner.
 const double ResonanceDecays::WIDTHCUT    = 5.;


### PR DESCRIPTION
Request from Sam Bein for lower threshold on MSAFETY in ResonanceDecays (only) to allow for pMSSM decays with really small mass splittings.