### PR TITLE
lower resonance width to 0.1 as in P8.240

### DIFF
--- a/src/ResonanceWidths.cc
+++ b/src/ResonanceWidths.cc
@@ -26,7 +26,7 @@ namespace Pythia8 {
 const int    ResonanceWidths::NPOINT         = 100;
 
 // The mass of a resonance must not be too small.
-const double ResonanceWidths::MASSMIN        = 0.4;
+const double ResonanceWidths::MASSMIN        = 0.1;
 
 // The sum of product masses must not be too close to the resonance mass.
 const double ResonanceWidths::MASSMARGIN     = 0.1;


### PR DESCRIPTION
The pull request was requested by Si in this thread. 
https://hypernews.cern.ch/HyperNews/CMS/get/generators/4751/1/1/2/1/1/1/1/1/1/1.html
The setting of 0.1 corresponds to what is used in P8.240. I didn't find anything else that needs a change. Let me add @smrenna . 