### PR TITLE
Backport fixes for alphaS running

### DIFF
--- a/include/Pythia8/MultipartonInteractions.h
+++ b/include/Pythia8/MultipartonInteractions.h
@@ -214,7 +214,7 @@ private:
                       SIGMAMBLIMIT;
 
   // Initialization data, read from Settings.
-  bool   allowRescatter, allowDoubleRes, canVetoMPI, doPartonVertex;
+  bool   allowRescatter, allowDoubleRes, canVetoMPI, doPartonVertex, alphaSfixRun;
   int    pTmaxMatch, alphaSorder, alphaEMorder, alphaSnfmax, bProfile,
          processLevel, bSelScale, rescatterMode, nQuarkIn, nSample,
          enhanceScreening, pT0paramMode;

--- a/include/Pythia8/SimpleSpaceShower.h
+++ b/include/Pythia8/SimpleSpaceShower.h
@@ -163,7 +163,7 @@ private:
   bool   doQCDshower, doQEDshowerByQ, doQEDshowerByL, useSamePTasMPI,
          doWeakShower, doMEcorrections, doMEafterFirst, doPhiPolAsym,
          doPhiPolAsymHard, doPhiIntAsym, doRapidityOrder, useFixedFacScale,
-         doSecondHard, canVetoEmission, hasUserHooks, alphaSuseCMW,
+         doSecondHard, canVetoEmission, hasUserHooks, alphaSuseCMW, alphaSfixRun,
          singleWeakEmission, vetoWeakJets, weakExternal, doRapidityOrderMPI,
          doMPI, doDipoleRecoil, doPartonVertex;
   int    pTmaxMatch, pTdampMatch, alphaSorder, alphaSnfmax, alphaEMorder,

--- a/include/Pythia8/SimpleTimeShower.h
+++ b/include/Pythia8/SimpleTimeShower.h
@@ -179,7 +179,7 @@ private:
          allowBeamRecoil, dampenBeamRecoil, recoilToColoured, useFixedFacScale,
          allowRescatter, canVetoEmission, doHVshower, brokenHVsym,
          globalRecoil, useLocalRecoilNow, doSecondHard, hasUserHooks,
-         singleWeakEmission, alphaSuseCMW, vetoWeakJets, allowMPIdipole,
+         singleWeakEmission, alphaSuseCMW, alphaSfixRun, vetoWeakJets, allowMPIdipole,
          weakExternal, recoilDeadCone,  doDipoleRecoil, doPartonVertex;
   int    pTmaxMatch, pTdampMatch, alphaSorder, alphaSnfmax, nGluonToQuark,
          weightGluonToQuark, alphaEMorder, nGammaToQuark, nGammaToLepton,

--- a/include/Pythia8/StandardModel.h
+++ b/include/Pythia8/StandardModel.h
@@ -28,7 +28,7 @@ public:
   AlphaStrong() : isInit(false), order(0), nfmax(),
     Lambda3Save(0.), Lambda4Save(0.), Lambda5Save(0.), Lambda6Save(0.),
     Lambda3Save2(0.), Lambda4Save2(0.), Lambda5Save2(0.), Lambda6Save2(0.),
-    scale2Min(0.), mc(0.), mb(0.), mt(0.), mc2(0.), mb2(0.), mt2(0.), useCMW(),
+    scale2Min(0.), mc(0.), mb(0.), mt(0.), mc2(0.), mb2(0.), mt2(0.), useCMW(), fixRunning(),
     lastCallToFull(false), valueRef(0.), valueNow(0.), scale2Now(0.) {}
 
   // Destructor.
@@ -36,7 +36,7 @@ public:
 
   // Initialization for given value at M_Z and given order.
   virtual void init(double valueIn = 0.12, int orderIn = 1, int nfmaxIn = 6,
-    bool useCMWIn = false);
+    bool useCMWIn = false, bool fixRunningIn = false);
 
   // Set flavour threshold values: m_c, m_b, m_t.
   virtual void setThresholds(double mcIn, double mbIn, double mtIn) {
@@ -81,6 +81,8 @@ protected:
 
   // CMW rescaling factors.
   bool useCMW;
+  // Fix alphaS running (backported from 8.309)
+  bool fixRunning;
   static const double FACCMW3, FACCMW4, FACCMW5, FACCMW6;
 
   // Safety margins to avoid getting too close to LambdaQCD.

--- a/share/Pythia8/xmldoc/CouplingsAndScales.xml
+++ b/share/Pythia8/xmldoc/CouplingsAndScales.xml
@@ -43,6 +43,12 @@ not go to second order there is no strong reason to use this option,
 but there is also nothing wrong with it.</option> 
 </modepick> 
  
+<flag name="SigmaProcess:alphaSfixRun" default="off"> 
+<option value="off">Do not apply the fix for 2-loop running. </option> 
+<option value="on">Apply the fix for 2-loop running, backported from 8.309. 
+</option> 
+</flag> 
+ 
 <p/> 
 QED interactions are regulated by the <ei>alpha_electromagnetic</ei> 
 value at the <ei>Q^2</ei> renormalization scale of an interaction. 

--- a/share/Pythia8/xmldoc/MultipartonInteractions.xml
+++ b/share/Pythia8/xmldoc/MultipartonInteractions.xml
@@ -99,6 +99,12 @@ not go to second order there is no strong reason to use this option,
 but there is also nothing wrong with it.</option> 
 </modepick> 
  
+<flag name="MultipartonInteractions:alphaSfixRun" default="off"> 
+<option value="off">Do not apply the fix for 2-loop running. </option> 
+<option value="on">Apply the fix for 2-loop running, backported from 8.309. 
+</option> 
+</flag> 
+ 
 <p/> 
 QED interactions are regulated by the <ei>alpha_electromagnetic</ei> 
 value at the <ei>pT^2</ei> scale of an interaction. 

--- a/share/Pythia8/xmldoc/SpacelikeShowers.xml
+++ b/share/Pythia8/xmldoc/SpacelikeShowers.xml
@@ -182,6 +182,12 @@ not go to second order there is no strong reason to use this option,
 but there is also nothing wrong with it.</option> 
 </modepick> 
  
+<flag name="SpaceShower:alphaSfixRun" default="off"> 
+<option value="off">Do not apply the fix for 2-loop running. </option> 
+<option value="on">Apply the fix for 2-loop running, backported from 8.309. 
+</option> 
+</flag> 
+ 
 <p/> 
 The CMW rescaling of <ei>Lambda_QCD</ei> (see the section on 
 <aloc href="StandardModelParameters">StandardModelParameters</aloc>) 

--- a/share/Pythia8/xmldoc/TimelikeShowers.xml
+++ b/share/Pythia8/xmldoc/TimelikeShowers.xml
@@ -188,6 +188,12 @@ not go to second order there is no strong reason to use this option,
 but there is also nothing wrong with it.</option> 
 </modepick> 
  
+<flag name="TimeShower:alphaSfixRun" default="off"> 
+<option value="off">Do not apply the fix for 2-loop running. </option> 
+<option value="on">Apply the fix for 2-loop running, backported from 8.309. 
+</option> 
+</flag> 
+ 
 <p/> 
 The CMW rescaling of <ei>Lambda_QCD</ei> (see the section on 
 <aloc href="StandardModelParameters">StandardModelParameters</aloc>) 

--- a/src/MergingHooks.cc
+++ b/src/MergingHooks.cc
@@ -2049,15 +2049,17 @@ void MergingHooks::init(){
   // Initialise AlphaS objects for reweighting
   double alphaSvalueFSR = settingsPtr->parm("TimeShower:alphaSvalue");
   int    alphaSorderFSR = settingsPtr->mode("TimeShower:alphaSorder");
+  bool   alphaSfixRunFSR= settingsPtr->flag("TimeShower:alphaSfixRun");
   int    alphaSnfmax    = settingsPtr->mode("StandardModel:alphaSnfmax");
   int    alphaSuseCMWFSR= settingsPtr->flag("TimeShower:alphaSuseCMW");
   AlphaS_FSRSave.init(alphaSvalueFSR, alphaSorderFSR, alphaSnfmax,
-    alphaSuseCMWFSR);
+    alphaSuseCMWFSR, alphaSfixRunFSR);
   double alphaSvalueISR = settingsPtr->parm("SpaceShower:alphaSvalue");
   int    alphaSorderISR = settingsPtr->mode("SpaceShower:alphaSorder");
+  bool   alphaSfixRunISR= settingsPtr->flag("SpaceShower:alphaSfixRun");
   int    alphaSuseCMWISR= settingsPtr->flag("SpaceShower:alphaSuseCMW");
   AlphaS_ISRSave.init(alphaSvalueISR, alphaSorderISR, alphaSnfmax,
-    alphaSuseCMWISR);
+    alphaSuseCMWISR, alphaSfixRunISR);
 
   // Initialise AlphaEM objects for reweighting
   int    alphaEMFSRorder = settingsPtr->mode("TimeShower:alphaEMorder");

--- a/src/MultipartonInteractions.cc
+++ b/src/MultipartonInteractions.cc
@@ -385,6 +385,7 @@ bool MultipartonInteractions::init( bool doMPIinit, int iDiffSysIn,
   //  Parameters of alphaStrong generation.
   alphaSvalue    = settings.parm("MultipartonInteractions:alphaSvalue");
   alphaSorder    = settings.mode("MultipartonInteractions:alphaSorder");
+  alphaSfixRun   = settings.flag("MultipartonInteractions:alphaSfixRun");
   alphaSnfmax    = settings.mode("StandardModel:alphaSnfmax");
 
   // Parameters of alphaEM generation.
@@ -502,7 +503,7 @@ bool MultipartonInteractions::init( bool doMPIinit, int iDiffSysIn,
   enhanceBavg    = 1.;
 
   // Initialize alpha_strong generation.
-  alphaS.init( alphaSvalue, alphaSorder, alphaSnfmax, false);
+  alphaS.init( alphaSvalue, alphaSorder, alphaSnfmax, false, alphaSfixRun);
   double Lambda3 = alphaS.Lambda3();
 
   // Initialize alphaEM generation.

--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -1839,6 +1839,7 @@ void Settings::resetTuneEE() {
   // FSR: strong coupling, IR cutoff.
   resetParm("TimeShower:alphaSvalue");
   resetMode("TimeShower:alphaSorder");
+  resetFlag("TimeShower:alphaSfixRun");
   resetFlag("TimeShower:alphaSuseCMW");
   resetParm("TimeShower:pTmin");
   resetParm("TimeShower:pTminChgQ");
@@ -1872,6 +1873,7 @@ void Settings::resetTunePP() {
   // ISR: strong coupling, IR cutoff, coherence and spin correlations.
   resetParm("SpaceShower:alphaSvalue");
   resetMode("SpaceShower:alphaSorder");
+  resetParm("SpaceShower:alphaSfixRun");
   resetParm("SpaceShower:alphaSuseCMW");
   resetFlag("SpaceShower:samePTasMPI");
   resetParm("SpaceShower:pT0Ref");
@@ -1886,6 +1888,8 @@ void Settings::resetTunePP() {
 
   // MPI: strong coupling, IR regularization, energy scaling.
   resetParm("MultipartonInteractions:alphaSvalue");
+  resetMode("MultipartonInteractions:alphaSorder");
+  resetParm("MultipartonInteractions:alphaSfixRun");
   resetParm("MultipartonInteractions:pT0Ref");
   resetParm("MultipartonInteractions:ecmRef");
   resetParm("MultipartonInteractions:ecmPow");

--- a/src/SimpleSpaceShower.cc
+++ b/src/SimpleSpaceShower.cc
@@ -135,12 +135,13 @@ void SimpleSpaceShower::init( BeamParticle* beamAPtrIn,
   // Parameters of alphaStrong generation.
   alphaSvalue     = settingsPtr->parm("SpaceShower:alphaSvalue");
   alphaSorder     = settingsPtr->mode("SpaceShower:alphaSorder");
+  alphaSfixRun    = settingsPtr->flag("SpaceShower:alphaSfixRun");
   alphaSnfmax     = settingsPtr->mode("StandardModel:alphaSnfmax");
   alphaSuseCMW    = settingsPtr->flag("SpaceShower:alphaSuseCMW");
   alphaS2pi       = 0.5 * alphaSvalue / M_PI;
 
   // Initialize alpha_strong generation.
-  alphaS.init( alphaSvalue, alphaSorder, alphaSnfmax, alphaSuseCMW);
+  alphaS.init( alphaSvalue, alphaSorder, alphaSnfmax, alphaSuseCMW, alphaSfixRun);
 
   // Lambda for 5, 4 and 3 flavours.
   Lambda5flav     = alphaS.Lambda5();

--- a/src/SimpleTimeShower.cc
+++ b/src/SimpleTimeShower.cc
@@ -1,5 +1,5 @@
 // SimpleTimeShower.cc is a part of the PYTHIA event generator.
-// Copyright (C) 2018 Torbjorn Sjostrand.
+// Copyright (C) 2019 Torbjorn Sjostrand.
 // PYTHIA is licenced under the GNU GPL v2 or later, see COPYING for details.
 // Please respect the MCnet Guidelines, see GUIDELINES for details.
 
@@ -3077,12 +3077,16 @@ bool SimpleTimeShower::branch( Event& event, bool isInterleaved) {
   int iSysSelRec   = dipSel->systemRec;
 
   // Sometimes need to patch up colType in junction systems.
-  int idRec        = recBef.id();
   int colTypeTmp   = dipSel->colType;
-  if (idRec >  0 && idRec < 9 && colTypeTmp > 0) colTypeTmp = -colTypeTmp;
-  if (idRec > -9 && idRec < 0 && colTypeTmp < 0) colTypeTmp = -colTypeTmp;
-  if (idRad >  0 && idRad < 9 && colTypeTmp < 0) colTypeTmp = -colTypeTmp;
-  if (idRad > -9 && idRad < 0 && colTypeTmp > 0) colTypeTmp = -colTypeTmp;
+  int colTypeRec   = particleDataPtr->colType( recBef.id() );
+  // Negate colour type if recoiler is initial-state quark.
+  if (!recBef.isFinal()) colTypeRec = -colTypeRec;
+  int colTypeRad   = particleDataPtr->colType( idRad );
+  // Perform junction tests for all colour (anti)triplets.
+  if (colTypeRec ==  1 && colTypeTmp > 0) colTypeTmp = -colTypeTmp;
+  if (colTypeRec == -1 && colTypeTmp < 0) colTypeTmp = -colTypeTmp;
+  if (colTypeRad ==  1 && colTypeTmp < 0) colTypeTmp = -colTypeTmp;
+  if (colTypeRad == -1 && colTypeTmp > 0) colTypeTmp = -colTypeTmp;
 
   // Default OK for photon, photon_HV or gluon_HV emission.
   if (dipSel->flavour == 22 || dipSel->flavour == idHV) {

--- a/src/SimpleTimeShower.cc
+++ b/src/SimpleTimeShower.cc
@@ -124,12 +124,13 @@ void SimpleTimeShower::init( BeamParticle* beamAPtrIn,
   // Parameters of alphaStrong generation.
   alphaSvalue        = settingsPtr->parm("TimeShower:alphaSvalue");
   alphaSorder        = settingsPtr->mode("TimeShower:alphaSorder");
+  alphaSfixRun       = settingsPtr->flag("TimeShower:alphaSfixRun");
   alphaSnfmax        = settingsPtr->mode("StandardModel:alphaSnfmax");
   alphaSuseCMW       = settingsPtr->flag("TimeShower:alphaSuseCMW");
   alphaS2pi          = 0.5 * alphaSvalue / M_PI;
 
   // Initialize alphaStrong generation.
-  alphaS.init( alphaSvalue, alphaSorder, alphaSnfmax, alphaSuseCMW);
+  alphaS.init( alphaSvalue, alphaSorder, alphaSnfmax, alphaSuseCMW, alphaSfixRun);
 
   // Lambda for 5, 4 and 3 flavours.
   Lambda3flav        = alphaS.Lambda3();

--- a/src/StandardModel.cc
+++ b/src/StandardModel.cc
@@ -40,7 +40,7 @@ const double AlphaStrong::FACCMW6         = 1.513;
 // Initialize alpha_strong calculation by finding Lambda values etc.
 
 void AlphaStrong::init( double valueIn, int orderIn, int nfmaxIn,
-  bool useCMWIn) {
+  bool useCMWIn, bool fixRunningIn) {
 
   // Set default mass thresholds if not already done
   if (mt <= 1.) setThresholds(1.5, 4.8, 171.0);
@@ -50,6 +50,7 @@ void AlphaStrong::init( double valueIn, int orderIn, int nfmaxIn,
   order    = max( 0, min( 3, orderIn ) );
   nfmax    = max( 5, min( 6, nfmaxIn ) );
   useCMW   = useCMWIn;
+  fixRunning = fixRunningIn;
   lastCallToFull = false;
   Lambda3Save = Lambda4Save = Lambda5Save = Lambda6Save = scale2Min = 0.;
 
@@ -83,7 +84,7 @@ void AlphaStrong::init( double valueIn, int orderIn, int nfmaxIn,
       logScale    = 2. * log(MZ/Lambda5Save);
       loglogScale = log(logScale);
       correction  = 1. - b15 * loglogScale / logScale;
-      if (order == 3) correction
+      if (order == 3 || !fixRunning) correction
         += pow2(b15 / logScale) * (pow2(loglogScale - 0.5) + b25 - 1.25);
       valueIter   = valueRef / correction;
       Lambda5Save = MZ * exp( -6. * M_PI / (23. * valueIter) );
@@ -93,7 +94,7 @@ void AlphaStrong::init( double valueIn, int orderIn, int nfmaxIn,
     double logScaleT    = 2. * log(mt/Lambda5Save);
     double loglogScaleT = log(logScaleT);
     correction =  1. - b15 * loglogScaleT / logScaleT;
-    if (order == 3) correction
+    if (order == 3 || !fixRunning) correction
       += pow2(b15 / logScaleT) * (pow2(loglogScaleT - 0.5) + b25 - 1.25);
     double valueT       = 12. * M_PI / (23. * logScaleT) * correction;
     Lambda6Save         = Lambda5Save;
@@ -101,7 +102,7 @@ void AlphaStrong::init( double valueIn, int orderIn, int nfmaxIn,
       logScale    = 2. * log(mt/Lambda6Save);
       loglogScale = log(logScale);
       correction  = 1. - b16 * loglogScale / logScale;
-      if (order == 3) correction
+      if (order == 3 || !fixRunning) correction
         += pow2(b16 / logScale) * (pow2(loglogScale - 0.5) + b26 - 1.25);
       valueIter   = valueT / correction;
       Lambda6Save = mt * exp( -6. * M_PI / (21. * valueIter) );
@@ -111,7 +112,7 @@ void AlphaStrong::init( double valueIn, int orderIn, int nfmaxIn,
     double logScaleB    = 2. * log(mb/Lambda5Save);
     double loglogScaleB = log(logScaleB);
     correction = 1. - b15 * loglogScaleB / logScaleB;
-    if (order == 3) correction
+    if (order == 3 || !fixRunning) correction
       += pow2(b15 / logScaleB) * (pow2(loglogScaleB - 0.5) + b25- 1.25);
     double valueB       = 12. * M_PI / (23. * logScaleB) * correction;
     Lambda4Save         = Lambda5Save;
@@ -119,7 +120,7 @@ void AlphaStrong::init( double valueIn, int orderIn, int nfmaxIn,
       logScale    = 2. * log(mb/Lambda4Save);
       loglogScale = log(logScale);
       correction  = 1. - b14 * loglogScale / logScale;
-      if (order == 3) correction
+      if (order == 3 || !fixRunning) correction
         += pow2(b14 / logScale) * (pow2(loglogScale - 0.5) + b24 - 1.25);
       valueIter   = valueB / correction;
       Lambda4Save = mb * exp( -6. * M_PI / (25. * valueIter) );
@@ -129,7 +130,7 @@ void AlphaStrong::init( double valueIn, int orderIn, int nfmaxIn,
     double logScaleC    = 2. * log(mc/Lambda4Save);
     double loglogScaleC = log(logScaleC);
     correction = 1. - b14 * loglogScaleC / logScaleC;
-    if (order == 3) correction
+    if (order == 3 || !fixRunning) correction
       += pow2(b14 / logScaleC) * (pow2(loglogScaleC - 0.5) + b24 - 1.25);
     double valueC       = 12. * M_PI / (25. * logScaleC) * correction;
     Lambda3Save = Lambda4Save;
@@ -137,7 +138,7 @@ void AlphaStrong::init( double valueIn, int orderIn, int nfmaxIn,
       logScale    = 2. * log(mc/Lambda3Save);
       loglogScale = log(logScale);
       correction  = 1. - b13 * loglogScale / logScale;
-      if (order == 3) correction
+      if (order == 3 || !fixRunning) correction
         += pow2(b13 / logScale) * (pow2(loglogScale - 0.5) + b23 - 1.25);
       valueIter   = valueC / correction;
       Lambda3Save = mc * exp( -6. * M_PI / (27. * valueIter) );
@@ -226,7 +227,7 @@ double AlphaStrong::alphaS( double scale2) {
     double logScale    = log(scale2/Lambda2);
     double loglogScale = log(logScale);
     double correction  = 1. - b1 * loglogScale / logScale;
-    if (order == 3) correction
+    if (order == 3 || !fixRunning) correction
       += pow2(b1 / logScale) * (pow2(loglogScale - 0.5) + b2 - 1.25);
     valueNow = 12. * M_PI / (b0 * logScale) * correction;
   }
@@ -307,7 +308,7 @@ double AlphaStrong::alphaS2OrdCorr( double scale2) {
   double logScale    = log(scale2/Lambda2);
   double loglogScale = log(logScale);
   double correction  = 1. - b1 * loglogScale / logScale;
-  if (order == 3) correction
+  if (order == 3 || !fixRunning) correction
     += pow2(b1 / logScale) * (pow2(loglogScale - 0.5) + b2 - 1.25);
   return correction;
 
@@ -446,8 +447,9 @@ void CoupSM::init(Settings& settings, Rndm* rndmPtrIn) {
   // Initialize the local AlphaStrong instance.
   double alphaSvalue  = settings.parm("SigmaProcess:alphaSvalue");
   int    alphaSorder  = settings.mode("SigmaProcess:alphaSorder");
+  int    alphaSfixRun = settings.flag("SigmaProcess:alphaSfixRun");
   int    alphaSnfmax  = settings.mode("StandardModel:alphaSnfmax");
-  alphaSlocal.init( alphaSvalue, alphaSorder, alphaSnfmax, false);
+  alphaSlocal.init( alphaSvalue, alphaSorder, alphaSnfmax, false, alphaSfixRun);
 
   // Initialize the local AlphaEM instance.
   int order = settings.mode("SigmaProcess:alphaEMorder");

--- a/src/UserHooks.cc
+++ b/src/UserHooks.cc
@@ -246,15 +246,18 @@ double SuppressSmallPT::multiplySigmaBy( const SigmaProcess* sigmaProcessPtr,
     // alternatively as for hard processes.
     double alphaSvalue;
     int    alphaSorder;
+    bool   alphaSfixRun;
     int    alphaSnfmax = settingsPtr->mode("StandardModel:alphaSnfmax");
     if (useSameAlphaSasMPI) {
       alphaSvalue = settingsPtr->parm("MultipartonInteractions:alphaSvalue");
       alphaSorder = settingsPtr->mode("MultipartonInteractions:alphaSorder");
+      alphaSfixRun = settingsPtr->flag("MultipartonInteractions:alphaSfixRun");
     } else {
       alphaSvalue = settingsPtr->parm("SigmaProcess:alphaSvalue");
       alphaSorder = settingsPtr->mode("SigmaProcess:alphaSorder");
+      alphaSfixRun = settingsPtr->flag("SigmaProcess:alphaSfixRun");
     }
-    alphaS.init( alphaSvalue, alphaSorder, alphaSnfmax, false);
+    alphaS.init( alphaSvalue, alphaSorder, alphaSnfmax, false, alphaSfixRun);
 
     // Initialization finished.
     isInit = true;


### PR DESCRIPTION
As discussed in https://github.com/cms-sw/cmsdist/pull/8552, backported from 8.309.

Deactivated by default, can be activated with:
```
SigmaProcess:alphaSfixRun = on
MultipartonInteractions:alphaSfixRun = on
SpaceShower:alphaSfixRun = on
TimeShower:alphaSfixRun = on
```

Should only be used for special samples requested by experts.